### PR TITLE
Guard trunk width calculation against missing frames

### DIFF
--- a/src/ui/designMode.test.js
+++ b/src/ui/designMode.test.js
@@ -1,4 +1,5 @@
-import pkg from '../../package.json' assert { type: 'json' };
+import { readFileSync } from 'fs';
+const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url)));
 import { TILE, COLL_TILE } from '../game/physics.js';
 import { CAMERA_OFFSET_Y } from '../render.js';
 

--- a/src/version.test.js
+++ b/src/version.test.js
@@ -1,4 +1,5 @@
-import pkg from '../package.json' assert { type: 'json' };
+import { readFileSync } from 'fs';
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
 import '../version.js';
 import { initUI } from './ui/index.js';
 

--- a/src/versionHtml.test.js
+++ b/src/versionHtml.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { TextEncoder, TextDecoder } from 'util';
-import pkg from '../package.json' assert { type: 'json' };
+const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)));
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- avoid crashes when trunk sprite frames missing by falling back to default width
- replace JSON import assertion in integration test with fs read
- document trunk spawn fallback and bump version to 2.16.2
- use fs reads for package.json in remaining tests to avoid CI parse errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c890a1b083329c425fb96edf0ca3